### PR TITLE
27 Add command line option to launch 3dmigoto and Genshin Impact

### DIFF
--- a/lib/flow/exe_arg.dart
+++ b/lib/flow/exe_arg.dart
@@ -1,0 +1,30 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'exe_arg.g.dart';
+
+@riverpod
+class ArgProvider extends _$ArgProvider {
+  static late List<String> initial;
+
+  @override
+  List<String> build() {
+    ref.onDispose(clear);
+    return initial;
+  }
+
+  void clear() {
+    final value = <String>[];
+    initial = value;
+    state = value;
+  }
+}
+
+enum AcceptedArg {
+  run3dm('/run3dm'),
+  rungame('/rungame'),
+  runboth('/runboth');
+
+  const AcceptedArg(this.cmd);
+
+  final String cmd;
+}

--- a/lib/flow/exe_arg.g.dart
+++ b/lib/flow/exe_arg.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'exe_arg.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$argProviderHash() => r'a2478803e099c57ee8badfb1bed5c50dd3d6484e';
+
+/// See also [ArgProvider].
+@ProviderFor(ArgProvider)
+final argProviderProvider =
+    AutoDisposeNotifierProvider<ArgProvider, List<String>>.internal(
+  ArgProvider.new,
+  name: r'argProviderProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$argProviderHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ArgProvider = AutoDisposeNotifier<List<String>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:genshin_mod_manager/error_handler.dart';
+import 'package:genshin_mod_manager/flow/exe_arg.dart';
 import 'package:genshin_mod_manager/ui/router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logger/logger.dart';
@@ -14,6 +15,7 @@ void main(final List<String> args) async {
   if (!kDebugMode) {
     registerErrorHandlers();
   }
+  ArgProvider.initial = args;
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/ui/route/home_shell.dart
+++ b/lib/ui/route/home_shell.dart
@@ -12,6 +12,7 @@ import 'package:genshin_mod_manager/domain/constant.dart';
 import 'package:genshin_mod_manager/domain/entity/mod_category.dart';
 import 'package:genshin_mod_manager/flow/app_state.dart';
 import 'package:genshin_mod_manager/flow/app_version.dart';
+import 'package:genshin_mod_manager/flow/exe_arg.dart';
 import 'package:genshin_mod_manager/flow/home_shell.dart';
 import 'package:genshin_mod_manager/ui/constant.dart';
 import 'package:genshin_mod_manager/ui/util/display_infobar.dart';
@@ -48,6 +49,44 @@ class _HomeShellState<T extends StatefulWidget> extends ConsumerState<HomeShell>
   void initState() {
     super.initState();
     WindowManager.instance.addListener(this);
+
+    final args = ref.read(argProviderProvider);
+    if (args.isNotEmpty) {
+      SchedulerBinding.instance.addPostFrameCallback(
+        (final timeStamp) {
+          final arg = args.first;
+          if (arg == AcceptedArg.run3dm.cmd) {
+            _runMigoto();
+          } else if (arg == AcceptedArg.rungame.cmd) {
+            _runLauncher();
+          } else if (arg == AcceptedArg.runboth.cmd) {
+            _runBoth();
+          } else {
+            unawaited(
+              showDialog(
+                context: context,
+                builder: (final dCtx) {
+                  final validArgs =
+                      AcceptedArg.values.map((final e) => e.cmd).join(', ');
+                  return ContentDialog(
+                    title: const Text('Invalid argument'),
+                    content: Text('Unknown argument: $arg.\n'
+                        'Valid args are: $validArgs'),
+                    actions: [
+                      FilledButton(
+                        onPressed: Navigator.of(dCtx).pop,
+                        child: const Text('OK'),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            );
+          }
+          ref.read(argProviderProvider.notifier).clear();
+        },
+      );
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: genshin_mod_manager
 description: Genshin mod manager.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.4.3+6
+version: 1.4.3+7
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
closes https://github.com/traveling-lumine/genshin_mod_manager/issues/27
## Checklist

- [ ] `cider bump <option>` (if merging to develop, use `cider bump build` instead)
- [ ] `flutter pub run flutter_oss_licenses:generate.dart`

## Related Issues
- Fixes #(issue number)

## Additional Information (if applicable)
Any additional information or context that might be relevant to this pull request.
